### PR TITLE
fix: enable react plugin in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+
 export default defineConfig({
-  plugins: [
-    tailwindcss(),
-  ],
+  plugins: [react(), tailwindcss()],
 })


### PR DESCRIPTION
## Summary
- enable React plugin in Vite configuration for proper JSX handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f20129fc88322ab5b0e1e0cb01f11