### PR TITLE
feat: redesign site with color and animations

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,21 +1,35 @@
 export default function ContactForm() {
     return (
-        <section id="contact" className="py-16">
+        <section
+            id="contact"
+            className="py-20 bg-gradient-to-r from-indigo-50 via-white to-indigo-50 animate-fade-in-up"
+        >
             <div className="mx-auto max-w-6xl px-4">
-                <h2 className="text-3xl font-bold">Book a Free Consultation</h2>
+                <h2 className="text-3xl font-bold text-center">Book a Free Consultation</h2>
                 <form
-                    className="mt-8 grid gap-4 max-w-xl"
+                    className="mt-10 grid gap-4 max-w-xl mx-auto"
                     onSubmit={(e) => {
                         e.preventDefault();
                         alert("Thanks! I’ll be in touch shortly.");
                     }}
                 >
-                    <input className="border rounded-xl px-4 py-3" placeholder="Your name" />
-                    <input className="border rounded-xl px-4 py-3" placeholder="Email address" type="email" />
-                    <textarea className="border rounded-xl px-4 py-3" placeholder="Your goals" rows={4} />
+                    <input
+                        className="border-2 border-indigo-200 rounded-xl px-4 py-3 focus:border-indigo-500 transition"
+                        placeholder="Your name"
+                    />
+                    <input
+                        className="border-2 border-indigo-200 rounded-xl px-4 py-3 focus:border-indigo-500 transition"
+                        placeholder="Email address"
+                        type="email"
+                    />
+                    <textarea
+                        className="border-2 border-indigo-200 rounded-xl px-4 py-3 focus:border-indigo-500 transition"
+                        placeholder="Your goals"
+                        rows={4}
+                    />
                     <button
                         type="submit"
-                        className="inline-flex items-center rounded-xl border border-indigo-600 px-5 py-3 font-semibold text-white bg-indigo-600 hover:bg-indigo-700 transition"
+                        className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-5 py-3 font-semibold text-white hover:bg-indigo-700 hover:-translate-y-0.5 transition-transform"
                     >
                         Send
                     </button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,9 @@
 export default function Footer() {
     return (
-        <footer className="py-8 border-t">
-            <div className="mx-auto max-w-6xl px-4 text-sm text-slate-500 flex flex-col md:flex-row items-center justify-between gap-3">
+        <footer className="py-8 bg-gradient-to-r from-indigo-600 to-purple-600 text-white animate-fade-in-up">
+            <div className="mx-auto max-w-6xl px-4 text-sm flex flex-col md:flex-row items-center justify-between gap-3">
                 <span>© {new Date().getFullYear()} KylePT. All rights reserved.</span>
-                <a href="#" className="hover:text-indigo-600">Privacy</a>
+                <a href="#" className="hover:underline">Privacy</a>
             </div>
         </footer>
     );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,8 +38,8 @@ export default function Header() {
     return (
         <header
             className={[
-                "sticky top-0 z-40 border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60",
-                elevated ? "shadow-sm" : "shadow-none",
+                "sticky top-0 z-40 bg-gradient-to-r from-indigo-600 to-purple-600 text-white",
+                elevated ? "shadow-lg" : "shadow-none",
             ].join(" ")}
         >
             {/* Skip link for accessibility */}
@@ -58,7 +58,7 @@ export default function Header() {
                     aria-label="KylePT home"
                 >
                     <span className="select-none">Kyle</span>
-                    <strong className="text-indigo-600 select-none">PT</strong>
+                    <strong className="text-yellow-300 select-none">PT</strong>
                 </a>
 
                 {/* Desktop nav */}
@@ -67,14 +67,14 @@ export default function Header() {
                         <a
                             key={l.href}
                             href={l.href}
-                            className="text-slate-700 hover:text-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+                            className="text-white/90 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
                         >
                             {l.label}
                         </a>
                     ))}
                     <a
                         href="#contact"
-                        className="ml-2 inline-flex items-center rounded-xl border border-indigo-600 px-4 py-2 text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition"
+                        className="ml-2 inline-flex items-center rounded-xl border border-white bg-white px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 transition"
                     >
                         Book a Free Consult
                     </a>
@@ -83,7 +83,7 @@ export default function Header() {
                 {/* Mobile toggle */}
                 <button
                     type="button"
-                    className="md:hidden inline-flex items-center justify-center rounded-lg border px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                    className="md:hidden inline-flex items-center justify-center rounded-lg border border-white/30 text-white px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                     onClick={() => setMobileOpen((v) => !v)}
                     aria-label="Toggle navigation"
                     aria-expanded={mobileOpen}
@@ -110,7 +110,7 @@ export default function Header() {
             <div
                 id="mobile-menu"
                 className={[
-                    "md:hidden overflow-hidden border-t bg-white will-change-[max-height,opacity]",
+                    "md:hidden overflow-hidden border-t border-white/20 bg-gradient-to-r from-indigo-700 to-purple-700 will-change-[max-height,opacity]",
                     mobileOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
                     "transition-all duration-300 ease-out",
                 ].join(" ")}
@@ -123,8 +123,8 @@ export default function Header() {
                             onClick={() => setMobileOpen(false)}
                             className={[
                                 "rounded-lg px-2 py-2",
-                                "text-slate-800 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500",
-                                l.href === "#contact" ? "font-semibold text-indigo-700" : "",
+                                "text-white/90 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60",
+                                l.href === "#contact" ? "font-semibold text-white" : "",
                             ].join(" ")}
                         >
                             {l.label}
@@ -133,7 +133,7 @@ export default function Header() {
                     <a
                         href="#contact"
                         onClick={() => setMobileOpen(false)}
-                        className="mt-1 inline-flex items-center justify-center rounded-xl border border-indigo-600 px-4 py-2 text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition"
+                        className="mt-1 inline-flex items-center justify-center rounded-xl bg-white px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 transition"
                     >
                         Book a Free Consult
                     </a>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ export default function Hero() {
     ];
 
     return (
-        <section className="relative overflow-hidden">
+        <section className="relative overflow-hidden animate-fade-in-up">
             {/* Soft background glow */}
             <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
                 <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl" />

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -2,22 +2,29 @@ import { PRICING_PLANS } from "../constants/site";
 
 export default function Pricing() {
     return (
-        <section id="pricing" className="py-16 bg-slate-50 border-y">
+        <section
+            id="pricing"
+            className="py-20 bg-gradient-to-r from-indigo-600 to-purple-600 text-white border-y animate-fade-in-up"
+        >
             <div className="mx-auto max-w-6xl px-4">
-                <h2 className="text-3xl font-bold">Pricing</h2>
-                <div className="mt-8 grid gap-6 md:grid-cols-3">
-                    {PRICING_PLANS.map((p) => (
-                        <div key={p.name} className="rounded-2xl border bg-white p-6 shadow-sm flex flex-col">
+                <h2 className="text-3xl font-bold text-center">Pricing</h2>
+                <div className="mt-10 grid gap-6 md:grid-cols-3">
+                    {PRICING_PLANS.map((p, i) => (
+                        <div
+                            key={p.name}
+                            className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 shadow-sm flex flex-col hover:-translate-y-1 hover:shadow-xl transition-transform animate-fade-in-up"
+                            style={{ animationDelay: `${i * 0.1}s` }}
+                        >
                             <h3 className="font-semibold text-lg">{p.name}</h3>
                             <div className="mt-2 text-3xl font-extrabold">{p.price}</div>
-                            <ul className="mt-4 space-y-2 text-slate-600">
+                            <ul className="mt-4 space-y-2 text-sm text-white/80">
                                 {p.features.map((f) => (
                                     <li key={f}>• {f}</li>
                                 ))}
                             </ul>
                             <a
                                 href="#contact"
-                                className="mt-6 inline-flex justify-center rounded-xl border border-indigo-600 px-4 py-2 font-semibold text-white bg-indigo-600 hover:bg-indigo-700 transition"
+                                className="mt-6 inline-flex justify-center rounded-xl bg-white px-4 py-2 font-semibold text-indigo-700 hover:bg-indigo-50 transition"
                             >
                                 Get Started
                             </a>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -2,13 +2,20 @@ import { SERVICES } from "../constants/site";
 
 export default function Services() {
     return (
-        <section id="services" className="py-16 bg-slate-50 border-t">
+        <section
+            id="services"
+            className="py-20 bg-gradient-to-r from-indigo-50 via-purple-50 to-pink-50 border-t animate-fade-in-up"
+        >
             <div className="mx-auto max-w-6xl px-4">
-                <h2 className="text-3xl font-bold">Services</h2>
-                <div className="mt-8 grid gap-6 md:grid-cols-3">
-                    {SERVICES.map((s) => (
-                        <div key={s.title} className="rounded-2xl border bg-white p-6 shadow-sm">
-                            <h3 className="font-semibold text-lg">{s.title}</h3>
+                <h2 className="text-3xl font-bold text-center">Services</h2>
+                <div className="mt-10 grid gap-6 md:grid-cols-3">
+                    {SERVICES.map((s, i) => (
+                        <div
+                            key={s.title}
+                            className="rounded-2xl border bg-white p-6 shadow-sm hover:shadow-lg hover:-translate-y-1 transition-transform animate-fade-in-up"
+                            style={{ animationDelay: `${i * 0.1}s` }}
+                        >
+                            <h3 className="font-semibold text-lg text-indigo-700">{s.title}</h3>
                             <p className="mt-2 text-slate-600">{s.desc}</p>
                         </div>
                     ))}

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -2,12 +2,19 @@ import { TESTIMONIALS } from "../constants/site";
 
 export default function Testimonials() {
     return (
-        <section id="testimonials" className="py-16">
+        <section
+            id="testimonials"
+            className="py-20 bg-gradient-to-r from-sky-50 via-white to-emerald-50 animate-fade-in-up"
+        >
             <div className="mx-auto max-w-6xl px-4">
-                <h2 className="text-3xl font-bold">Client Results</h2>
-                <div className="mt-8 grid gap-6 md:grid-cols-3">
+                <h2 className="text-3xl font-bold text-center">Client Results</h2>
+                <div className="mt-10 grid gap-6 md:grid-cols-3">
                     {TESTIMONIALS.map((t, i) => (
-                        <figure key={i} className="rounded-2xl border p-6 bg-white shadow-sm">
+                        <figure
+                            key={i}
+                            className="rounded-2xl border bg-white p-6 shadow-sm hover:shadow-lg hover:-translate-y-1 transition-transform animate-fade-in-up"
+                            style={{ animationDelay: `${i * 0.1}s` }}
+                        >
                             <blockquote className="text-slate-800">{t}</blockquote>
                             <figcaption className="mt-3 text-sm text-slate-500">— Happy client</figcaption>
                         </figure>

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+body {
+  @apply bg-gradient-to-b from-indigo-50 via-white to-sky-50 text-slate-900 antialiased;
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,9 +1,11 @@
 
 export default function About() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">About</h1>
-      <p>Learn more about us on this page.</p>
+    <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-sky-50 p-8 flex flex-col items-center text-center animate-fade-in-up">
+      <h1 className="text-4xl font-extrabold mb-6 text-indigo-700">About</h1>
+      <p className="text-lg text-slate-700 max-w-2xl">
+        Learn more about us on this page.
+      </p>
     </div>
   );
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,9 +1,11 @@
 
 export default function Contact() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Contact</h1>
-      <p>Get in touch through the contact form below.</p>
+    <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-sky-50 p-8 flex flex-col items-center text-center animate-fade-in-up">
+      <h1 className="text-4xl font-extrabold mb-6 text-indigo-700">Contact</h1>
+      <p className="text-lg text-slate-700 max-w-2xl">
+        Get in touch through the contact form below.
+      </p>
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,7 +8,7 @@ import Footer from "../components/Footer";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-white text-slate-900">
+    <div className="min-h-screen text-slate-900 space-y-24">
       <Header />
       <Hero />
       <Services />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,9 +1,9 @@
 
 export default function NotFound() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">404 - Not Found</h1>
-      <p>The page you are looking for does not exist.</p>
+    <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-sky-50 p-8 flex flex-col items-center text-center animate-fade-in-up">
+      <h1 className="text-4xl font-extrabold mb-6 text-indigo-700">404 - Not Found</h1>
+      <p className="text-lg text-slate-700 max-w-2xl">The page you are looking for does not exist.</p>
     </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,17 @@ export default {
         "./src/**/*.{ts,tsx}"
     ],
     theme: {
-        extend: {}
+        extend: {
+            keyframes: {
+                'fade-in-up': {
+                    '0%': { opacity: '0', transform: 'translateY(20px)' },
+                    '100%': { opacity: '1', transform: 'translateY(0)' },
+                },
+            },
+            animation: {
+                'fade-in-up': 'fade-in-up 0.6s ease-out both',
+            },
+        }
     },
     plugins: []
 }


### PR DESCRIPTION
## Summary
- add fade-in animations and gradient theme using Tailwind
- redesign key sections (header, services, pricing, contact) with vibrant colors and hover effects
- apply global gradient background across pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f28fce2ac8322a9fa33adf95acb5f