### PR TITLE
Brand site as personal training

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Project Kizzle</title>
+    <title>Kyle PT – Personal Training</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -55,9 +55,9 @@ export default function Header() {
                 <a
                     href="/"
                     className="inline-flex items-center gap-2 font-extrabold tracking-tight text-xl"
-                    aria-label="Project Kizzle Home"
+                    aria-label="Kyle PT Home"
                 >
-                    <span className="select-none">Project Kizzle</span>
+                    <span className="select-none">Kyle PT</span>
                 </a>
 
                 {/* Desktop nav */}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,7 +6,7 @@ export default function Hero() {
                 className="absolute inset-0 bg-cover bg-center"
                 style={{
                     backgroundImage:
-                        "url('https://images.unsplash.com/photo-1596357395104-5e7e7528f1b3?q=80&w=2000&auto=format&fit=crop')",
+                        "url('https://images.unsplash.com/photo-1594737625785-c8fb6d711f40?q=80&w=2000&auto=format&fit=crop')",
                 }}
                 aria-hidden
             />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,11 +1,18 @@
 
 export default function About() {
-  return (
-    <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-sky-50 p-8 flex flex-col items-center text-center animate-fade-in-up">
-      <h1 className="text-4xl font-extrabold mb-6 text-indigo-700">About</h1>
-      <p className="text-lg text-slate-700 max-w-2xl">
-        Learn more about us on this page.
-      </p>
-    </div>
-  );
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-sky-50 p-8 flex flex-col items-center text-center animate-fade-in-up">
+            <h1 className="text-4xl font-extrabold mb-6 text-indigo-700">Meet Your Trainer</h1>
+            <img
+                src="https://images.unsplash.com/photo-1558611848-73f7eb4001a1?q=80&w=800&auto=format&fit=crop"
+                alt="Personal trainer coaching a client"
+                className="w-64 h-64 object-cover rounded-full shadow mb-6"
+            />
+            <p className="text-lg text-slate-700 max-w-2xl">
+                I'm Kyle, a certified personal trainer with over a decade of experience helping people build strength,
+                move better, and feel amazing. Whether you're new to the gym or chasing performance goals, we'll create
+                a plan that fits your life and keeps you motivated.
+            </p>
+        </div>
+    );
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -4,7 +4,7 @@ export default function Contact() {
     <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-sky-50 p-8 flex flex-col items-center text-center animate-fade-in-up">
       <h1 className="text-4xl font-extrabold mb-6 text-indigo-700">Contact</h1>
       <p className="text-lg text-slate-700 max-w-2xl">
-        Get in touch through the contact form below.
+        Have questions or ready to start training? Send a message and I'll get back within a day.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Rename site and header branding to Kyle PT for a personal training focus
- Swap hero background for a trainer-client photo
- Add trainer bio and imagery on About page and update contact messaging

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f2c13cab88322a17ceb27b15428e7