### PR TITLE
Reset color palette

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,11 +11,12 @@
   will-change: filter;
   transition: filter 300ms;
 }
+
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em #14b3c4aa);
 }
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em #14b3c4aa);
 }
 
 @keyframes logo-spin {
@@ -38,5 +39,5 @@
 }
 
 .read-the-docs {
-  color: #888;
+  color: #6b7280;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -109,7 +109,7 @@ export default function Header() {
             <div
                 id="mobile-menu"
                 className={[
-                    "md:hidden overflow-hidden border-t border-white/20 bg-gradient-to-r from-brand-dark to-[#c45e14] will-change-[max-height,opacity]",
+                    "md:hidden overflow-hidden border-t border-white/20 bg-gradient-to-r from-brand-dark to-brand will-change-[max-height,opacity]",
                     mobileOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
                     "transition-all duration-300 ease-out",
                 ].join(" ")}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -16,7 +16,7 @@ export default function Hero() {
             {/* Content */}
             <div className="relative z-10 mx-auto max-w-5xl px-4 text-center text-white">
                 <h1 className="text-4xl md:text-6xl font-extrabold tracking-tight">
-                    Build Strength. <span className="text-[#14b3c4]">Own Your Movement.</span>
+                    Build Strength. <span className="text-brand">Own Your Movement.</span>
                 </h1>
                 <p className="mt-4 text-lg text-white/90 max-w-2xl mx-auto">
                     Personal training that scales to your life: smart programming, form-first coaching, real results.

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -4,7 +4,7 @@ export default function Pricing() {
     return (
         <section
             id="pricing"
-            className="py-20 bg-gradient-to-r from-brand-dark to-[#c45e14] text-white border-y animate-fade-in-up"
+            className="py-20 bg-gradient-to-r from-brand-dark to-brand text-white border-y animate-fade-in-up"
         >
             <div className="mx-auto max-w-6xl px-4">
                 <h2 className="text-3xl font-bold text-center">Pricing</h2>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -4,7 +4,7 @@ export default function Services() {
     return (
         <section
             id="services"
-            className="py-20 bg-gradient-to-r from-neutral-100 via-white to-[#c45e14] border-t animate-fade-in-up"
+            className="py-20 bg-gradient-to-r from-neutral-100 via-white to-brand border-t animate-fade-in-up"
         >
             <div className="mx-auto max-w-6xl px-4">
                 <h2 className="text-3xl font-bold text-center">Services</h2>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -4,7 +4,7 @@ export default function Testimonials() {
     return (
         <section
             id="testimonials"
-            className="py-20 bg-gradient-to-r from-[#14b3c4] via-white to-[#14b3c4] animate-fade-in-up"
+            className="py-20 bg-gradient-to-r from-brand-dark via-white to-brand animate-fade-in-up"
         >
             <div className="mx-auto max-w-6xl px-4">
                 <h2 className="text-3xl font-bold text-center">Client Results</h2>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,7 +1,7 @@
 
 export default function About() {
     return (
-        <div className="min-h-screen bg-gradient-to-b from-neutral-100 via-white to-[#14b3c4] p-8 flex flex-col items-center text-center animate-fade-in-up">
+        <div className="min-h-screen bg-gradient-to-b from-neutral-100 via-white to-brand p-8 flex flex-col items-center text-center animate-fade-in-up">
             <h1 className="text-4xl font-extrabold mb-6 text-brand">Meet Your Trainer</h1>
             <img
                 src="https://images.unsplash.com/photo-1558611848-73f7eb4001a1?q=80&w=800&auto=format&fit=crop"

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,7 +1,7 @@
 
 export default function Contact() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-neutral-100 via-white to-[#14b3c4] p-8 flex flex-col items-center text-center animate-fade-in-up">
+    <div className="min-h-screen bg-gradient-to-b from-neutral-100 via-white to-brand p-8 flex flex-col items-center text-center animate-fade-in-up">
       <h1 className="text-4xl font-extrabold mb-6 text-brand">Contact</h1>
       <p className="text-lg text-neutral-900 max-w-2xl">
         Have questions or ready to start training? Send a message and I'll get back within a day.

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-neutral-100 via-white to-[#14b3c4] p-8 flex flex-col items-center text-center animate-fade-in-up">
+    <div className="min-h-screen bg-gradient-to-b from-neutral-100 via-white to-brand p-8 flex flex-col items-center text-center animate-fade-in-up">
       <h1 className="text-4xl font-extrabold mb-6 text-brand">404 - Not Found</h1>
       <p className="text-lg text-neutral-900 max-w-2xl">The page you are looking for does not exist.</p>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,13 +8,13 @@ export default {
         extend: {
             colors: {
                 brand: {
-                    DEFAULT: '#c41d14',
-                    dark: '#8f130f',
-                    light: '#ff6f60',
+                    DEFAULT: '#14b3c4',
+                    dark: '#0e8fa5',
+                    light: '#5dd5e5',
                 },
                 neutral: {
-                    100: '#f2e7e7',
-                    900: '#432022',
+                    100: '#f3f4f6',
+                    900: '#111827',
                 },
             },
             keyframes: {


### PR DESCRIPTION
## Summary
- Define cohesive brand and neutral colors in Tailwind configuration
- Replace hard-coded hex values with brand gradients across components
- Align miscellaneous styling like drop-shadows with the new palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f63e7b5d4832296dfd37133347390